### PR TITLE
Add GitHub Actions job to verify ROSbag build with bagzel

### DIFF
--- a/.github/workflows/rosbags_build_check.yml
+++ b/.github/workflows/rosbags_build_check.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 Leon Pohl <leon.pohl@unibw.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Rosbags Build Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  rosbags_build_check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        lfs: true  # optional, but helps ensure LFS files are fetched
+    
+    - name: Pull Git LFS objects
+      run: git lfs pull
+
+    - name: Build rosbags with Bazel
+      uses: addnab/docker-run-action@v3
+      with:
+        image: gcr.io/bazel-public/bazel:latest
+        options: -v ${{ github.workspace }}:/workspace -w /workspace
+        run: |
+          bazel build //data:rosbags_sub1_all
+

--- a/.gitlab-ci.bagzel.yml
+++ b/.gitlab-ci.bagzel.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Leon Pohl <leon.pohl@unibw.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+build_bagzel:
+  stage: build
+  image:
+    name: gcr.io/bazel-public/bazel:latest
+    entrypoint: [""]
+  parallel:
+    matrix:
+      - TARGET: "//data:rosbags_sub1_all"
+        LABEL: "Build Rosbags"
+      - TARGET: "//src:everything"
+        LABEL: "Build Code"
+  script:
+    - cd cluster/bagzel/
+    - bazel build "$TARGET"
+  only:
+    - branches
+    - merge_requests

--- a/src/python/BUILD
+++ b/src/python/BUILD
@@ -1,0 +1,10 @@
+# ------------------------------------------------------------------------------
+# Group target to build all Python binaries in this package
+# ------------------------------------------------------------------------------
+filegroup(
+    name = "everything",
+    srcs = [
+        "//src/python/tools:everything",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This pull request introduces a GitHub Action to automatically verify that ROSbag builds correctly using Bagzel. This helps ensure build integrity and catch regressions early in the CI pipeline.